### PR TITLE
Fixed a typo in the Hiera example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class { 'ssh':
 ```yaml
 ssh::storeconfigs_enabled: true
 
-ssh::server_options:
+ssh::server::options:
     Protocol: '2'
     ListenAddress:
         - '127.0.0.0'


### PR DESCRIPTION
For the Hiera server example you had ssh::server_options instead of ssh::server::options.